### PR TITLE
feature: added the "language" parameter to let the release notes to be generated in the specified language. Defaults to english.

### DIFF
--- a/.jest/setEnvVars.ts
+++ b/.jest/setEnvVars.ts
@@ -1,0 +1,4 @@
+import process from "process";
+
+process.env.GITHUB_REPOSITORY = 'owner/repo'
+process.env.GITHUB_TOKEN = 'mock-token'

--- a/.jest/setEnvVars.ts
+++ b/.jest/setEnvVars.ts
@@ -1,4 +1,4 @@
-import process from "process";
+import process from 'process'
 
 process.env.GITHUB_REPOSITORY = 'owner/repo'
 process.env.GITHUB_TOKEN = 'mock-token'

--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ env:
 
 ## Action Inputs
 
-| Input | Required | Description |
-| --- | --- | --- |
-| `version` | Yes | The version number or release name (string) |
-| `whimsical` | No | Whether to create a plain release text or a whimsical one (boolean) |
-| `sha` | No | The starting sha or committish for getting commit messages. uses the latest release as base or the whole of main if there are no releases (string) |
-| `project_name` | No | The project name to communicate to ChatGPT, uses the repo name if not set (string) |
+| Input | Required | Description                                                                                                                                                                                                                                                               |
+| --- | --- |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `version` | Yes | The version number or release name (string)                                                                                                                                                                                                                               |
+| `whimsical` | No | Whether to create a plain release text or a whimsical one (boolean)                                                                                                                                                                                                       |
+| `sha` | No | The starting sha or committish for getting commit messages. uses the latest release as base or the whole of main if there are no releases (string)                                                                                                                        |
+| `project_name` | No | The project name to communicate to ChatGPT, uses the repo name if not set (string)                                                                                                                                                                                        |
+| `language` | No | The language in which the release text has to be written. `english` if not set. (string)<br/>Supported languages are: <br/>- `english`<br/>- `spanish`<br/>-  `french`<br/>- `german`<br/>- `italian`<br/>- `portuguese`<br/>- `russian`<br/>- `japanese`<br/>- `chinese` |
+
 
 ## Build and Test this Action Locally
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -132,3 +132,58 @@ describe('isNullOrWhitespace', () => {
     expect(result2).toBe(true);
   });
 })
+
+
+describe('throwIfLanguageIsNotSupported', () => {
+  test('should throw an error for unsupported language', () => {
+    expect(() => {
+      throwIfLanguageIsNotSupported('italiano');
+    }).toThrowError('Language italiano is not supported.');
+
+    expect(() => {
+      throwIfLanguageIsNotSupported('abcde');
+    }).toThrowError('Language abcde is not supported.');
+  });
+
+  test('should not throw an error for supported language', () => {
+    expect(() => {
+      throwIfLanguageIsNotSupported('german');
+    }).not.toThrow();
+  });
+
+  test('should not throw an error for supported language with front and end spaces', () => {
+    expect(() => {
+      throwIfLanguageIsNotSupported('    english');
+    }).not.toThrow();
+    expect(() => {
+      throwIfLanguageIsNotSupported('english     ');
+    }).not.toThrow();
+    expect(() => {
+      throwIfLanguageIsNotSupported('    english     ');
+    }).not.toThrow();
+  });
+
+  test('should not throw an error for all supported languages', () => {
+    supportedLanguages.forEach((language) => {
+      expect(() => {
+        throwIfLanguageIsNotSupported(language);
+      }).not.toThrow();
+    });
+  });
+
+  test('should ignore case when checking supported languages', () => {
+    expect(() => {
+      throwIfLanguageIsNotSupported('SpaNisH');
+    }).not.toThrow();
+  });
+
+  test('should throw an error for empty or whitespace string language', () => {
+    expect(() => {
+      throwIfLanguageIsNotSupported('');
+    }).toThrowError('Language  is not supported.');
+    expect(() => {
+      throwIfLanguageIsNotSupported('    ');
+    }).toThrowError('Language      is not supported.');
+  });
+
+})

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -3,10 +3,13 @@ import {expect, test, describe} from '@jest/globals'
 import {getSha, getMessages} from '../src/business'
 
 import nock from 'nock'
-process.env.GITHUB_REPOSITORY = 'owner/repo'
+import {isNullOrWhitespace} from "../src/stringsHelper";
+import {supportedLanguages, throwIfLanguageIsNotSupported} from "../src/supportedLanguages";
+
 
 describe('getSha', () => {
   test('returns the target commitish of the latest release', async () => {
+
     // Mock the GitHub API response
     const expectedSha = 'abcdef123456'
     nock('https://api.github.com')
@@ -61,4 +64,71 @@ describe('getMessages', () => {
     // Call the function and expect it to throw an error
     await expect(getMessages(sha)).rejects.toThrow()
   })
+})
+
+describe('isNullOrWhitespace', () => {
+  test('should return true for null input', () => {
+    const result = isNullOrWhitespace(null)
+    expect(result).toBe(true)
+  })
+
+  test('should return true for undefined input', () => {
+    const result = isNullOrWhitespace(undefined)
+    expect(result).toBe(true)
+  })
+
+  test('should return true for empty string input', () => {
+    const result = isNullOrWhitespace('')
+    expect(result).toBe(true)
+  })
+
+  test('should return true for whitespace string input', () => {
+    const result = isNullOrWhitespace('   ')
+    expect(result).toBe(true)
+  })
+
+  test('should return true for new line string input', () => {
+    const result = isNullOrWhitespace('\n')
+    expect(result).toBe(true)
+  })
+
+  test("should return true for string with white spaces and other special characters", () => {
+    const result = isNullOrWhitespace(" \n \t ");
+    expect(result).toBe(true);
+  });
+
+
+  test('should return false for non-empty string input', () => {
+    const result = isNullOrWhitespace('hello')
+    expect(result).toBe(false)
+  })
+
+  test('should return false for non-empty string input even if it has some white spaces inside', () => {
+    const result = isNullOrWhitespace('hello Moto')
+    expect(result).toBe(false)
+  })
+
+  test("should return false for string with non-white space characters", () => {
+    const result = isNullOrWhitespace("Hello, world!");
+    expect(result).toBe(false);
+  });
+
+  test("should handle strings with unicode characters", () => {
+    const result = isNullOrWhitespace("Héllo, 🌎!");
+    expect(result).toBe(false);
+  });
+
+  test("should handle strings with spaces only at the beginning or end", () => {
+    const result1 = isNullOrWhitespace("  Hello");
+    const result2 = isNullOrWhitespace("Hello   ");
+    expect(result1).toBe(false);
+    expect(result2).toBe(false);
+  });
+
+  test("should handle strings with only tabs or line breaks", () => {
+    const result1 = isNullOrWhitespace("\t\t");
+    const result2 = isNullOrWhitespace("\n\n\n");
+    expect(result1).toBe(true);
+    expect(result2).toBe(true);
+  });
 })

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -3,13 +3,14 @@ import {expect, test, describe} from '@jest/globals'
 import {getSha, getMessages} from '../src/business'
 
 import nock from 'nock'
-import {isNullOrWhitespace} from "../src/stringsHelper";
-import {supportedLanguages, throwIfLanguageIsNotSupported} from "../src/supportedLanguages";
-
+import {isNullOrWhitespace} from '../src/stringsHelper'
+import {
+  supportedLanguages,
+  throwIfLanguageIsNotSupported
+} from '../src/supportedLanguages'
 
 describe('getSha', () => {
   test('returns the target commitish of the latest release', async () => {
-
     // Mock the GitHub API response
     const expectedSha = 'abcdef123456'
     nock('https://api.github.com')
@@ -92,11 +93,10 @@ describe('isNullOrWhitespace', () => {
     expect(result).toBe(true)
   })
 
-  test("should return true for string with white spaces and other special characters", () => {
-    const result = isNullOrWhitespace(" \n \t ");
-    expect(result).toBe(true);
-  });
-
+  test('should return true for string with white spaces and other special characters', () => {
+    const result = isNullOrWhitespace(' \n \t ')
+    expect(result).toBe(true)
+  })
 
   test('should return false for non-empty string input', () => {
     const result = isNullOrWhitespace('hello')
@@ -108,82 +108,80 @@ describe('isNullOrWhitespace', () => {
     expect(result).toBe(false)
   })
 
-  test("should return false for string with non-white space characters", () => {
-    const result = isNullOrWhitespace("Hello, world!");
-    expect(result).toBe(false);
-  });
+  test('should return false for string with non-white space characters', () => {
+    const result = isNullOrWhitespace('Hello, world!')
+    expect(result).toBe(false)
+  })
 
-  test("should handle strings with unicode characters", () => {
-    const result = isNullOrWhitespace("Héllo, 🌎!");
-    expect(result).toBe(false);
-  });
+  test('should handle strings with unicode characters', () => {
+    const result = isNullOrWhitespace('Héllo, 🌎!')
+    expect(result).toBe(false)
+  })
 
-  test("should handle strings with spaces only at the beginning or end", () => {
-    const result1 = isNullOrWhitespace("  Hello");
-    const result2 = isNullOrWhitespace("Hello   ");
-    expect(result1).toBe(false);
-    expect(result2).toBe(false);
-  });
+  test('should handle strings with spaces only at the beginning or end', () => {
+    const result1 = isNullOrWhitespace('  Hello')
+    const result2 = isNullOrWhitespace('Hello   ')
+    expect(result1).toBe(false)
+    expect(result2).toBe(false)
+  })
 
-  test("should handle strings with only tabs or line breaks", () => {
-    const result1 = isNullOrWhitespace("\t\t");
-    const result2 = isNullOrWhitespace("\n\n\n");
-    expect(result1).toBe(true);
-    expect(result2).toBe(true);
-  });
+  test('should handle strings with only tabs or line breaks', () => {
+    const result1 = isNullOrWhitespace('\t\t')
+    const result2 = isNullOrWhitespace('\n\n\n')
+    expect(result1).toBe(true)
+    expect(result2).toBe(true)
+  })
 })
-
 
 describe('throwIfLanguageIsNotSupported', () => {
   test('should throw an error for unsupported language', () => {
     expect(() => {
-      throwIfLanguageIsNotSupported('italiano');
-    }).toThrowError('Language italiano is not supported.');
+      throwIfLanguageIsNotSupported('italiano')
+    }).toThrowError('Language italiano is not supported.')
 
     expect(() => {
-      throwIfLanguageIsNotSupported('abcde');
-    }).toThrowError('Language abcde is not supported.');
-  });
+      throwIfLanguageIsNotSupported('abcde')
+    }).toThrowError('Language abcde is not supported.')
+  })
 
   test('should not throw an error for supported language', () => {
     expect(() => {
-      throwIfLanguageIsNotSupported('german');
-    }).not.toThrow();
-  });
+      throwIfLanguageIsNotSupported('german')
+    }).not.toThrow()
+  })
 
   test('should not throw an error for supported language with front and end spaces', () => {
     expect(() => {
-      throwIfLanguageIsNotSupported('    english');
-    }).not.toThrow();
+      throwIfLanguageIsNotSupported('    english')
+    }).not.toThrow()
     expect(() => {
-      throwIfLanguageIsNotSupported('english     ');
-    }).not.toThrow();
+      throwIfLanguageIsNotSupported('english     ')
+    }).not.toThrow()
     expect(() => {
-      throwIfLanguageIsNotSupported('    english     ');
-    }).not.toThrow();
-  });
+      throwIfLanguageIsNotSupported('    english     ')
+    }).not.toThrow()
+  })
 
   test('should not throw an error for all supported languages', () => {
-    supportedLanguages.forEach((language) => {
+    supportedLanguages.forEach(language => {
       expect(() => {
-        throwIfLanguageIsNotSupported(language);
-      }).not.toThrow();
-    });
-  });
+        throwIfLanguageIsNotSupported(language)
+      }).not.toThrow()
+    })
+  })
 
   test('should ignore case when checking supported languages', () => {
     expect(() => {
-      throwIfLanguageIsNotSupported('SpaNisH');
-    }).not.toThrow();
-  });
+      throwIfLanguageIsNotSupported('SpaNisH')
+    }).not.toThrow()
+  })
 
   test('should throw an error for empty or whitespace string language', () => {
     expect(() => {
-      throwIfLanguageIsNotSupported('');
-    }).toThrowError('Language  is not supported.');
+      throwIfLanguageIsNotSupported('')
+    }).toThrowError('Language  is not supported.')
     expect(() => {
-      throwIfLanguageIsNotSupported('    ');
-    }).toThrowError('Language      is not supported.');
-  });
-
+      throwIfLanguageIsNotSupported('    ')
+    }).toThrowError('Language      is not supported.')
+  })
 })

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,5 +5,6 @@ module.exports = {
   transform: {
     '^.+\\.ts$': 'ts-jest'
   },
-  verbose: true
+  verbose: true,
+  setupFiles: ['./.jest/setEnvVars.ts']
 }

--- a/src/business.ts
+++ b/src/business.ts
@@ -2,6 +2,7 @@ import * as core from '@actions/core'
 import * as github from '@actions/github'
 import {Configuration, OpenAIApi} from 'openai'
 import {isNullOrWhitespace} from './stringsHelper'
+import { throwIfLanguageIsNotSupported } from "./supportedLanguages";
 
 if (!process.env.GITHUB_TOKEN) throw new Error('No GITHUB_TOKEN set')
 
@@ -54,9 +55,11 @@ export async function generateRelease(
   const openai = new OpenAIApi(configuration)
   const jointMessages = messages.join('\n')
 
-  const languagePrompt = !isNullOrWhitespace(language)
-    ? `Write the message using the ${language} language.`
-    : null
+  let languagePrompt: string | null = null
+  if (!isNullOrWhitespace(language)) {
+    throwIfLanguageIsNotSupported(language)
+    languagePrompt = `Write the message using the ${language} language.`
+  }
 
   const prompt = whimsical
     ? `Generate release notes for version ${releaseName}. The project name is ${projectName}. The tone should be fun and whimsical, yet informative. Use the following commit messages:\n\n${jointMessages}\n\n. ${languagePrompt}`

--- a/src/business.ts
+++ b/src/business.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core'
 import * as github from '@actions/github'
 import {Configuration, OpenAIApi} from 'openai'
 import {isNullOrWhitespace} from './stringsHelper'
-import { throwIfLanguageIsNotSupported } from "./supportedLanguages";
+import {throwIfLanguageIsNotSupported} from './supportedLanguages'
 
 if (!process.env.GITHUB_TOKEN) throw new Error('No GITHUB_TOKEN set')
 
@@ -55,15 +55,20 @@ export async function generateRelease(
   const openai = new OpenAIApi(configuration)
   const jointMessages = messages.join('\n')
 
+  const generateReleaseNotesPromptWithoutLanguageSpecification = whimsical
+    ? `Generate release notes for version ${releaseName}. The project name is ${projectName}. The tone should be fun and whimsical, yet informative. Use the following commit messages:\n\n${jointMessages}`
+    : `Generate release notes for version ${releaseName}, for project ${projectName}, based on the following commit messages:\n\n${process.env.COMMIT_MESSAGES}`
+
   let languagePrompt: string | null = null
   if (!isNullOrWhitespace(language)) {
     throwIfLanguageIsNotSupported(language)
-    languagePrompt = `Write the message using the ${language} language.`
+    languagePrompt = `translate the message to ${language}`
   }
 
-  const prompt = whimsical
-    ? `Generate release notes for version ${releaseName}. The project name is ${projectName}. The tone should be fun and whimsical, yet informative. Use the following commit messages:\n\n${jointMessages}\n\n. ${languagePrompt}`
-    : `Generate release notes for version ${releaseName}, for project ${projectName}, based on the following commit messages:\n\n${process.env.COMMIT_MESSAGES}\n\n. ${languagePrompt}`
+  const prompt = languagePrompt
+    ? `Please first ${generateReleaseNotesPromptWithoutLanguageSpecification} and then ${languagePrompt}`
+    : generateReleaseNotesPromptWithoutLanguageSpecification
+
   try {
     const completions = await openai.createCompletion({
       model: 'text-davinci-003',

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,12 +9,14 @@ async function run(): Promise<void> {
     const sha: string = core.getInput('sha') ?? (await getSha())
     const projectName: string =
       core.getInput('project_name') ?? github.context.repo.repo
+    const language: string = core.getInput('language')
 
     core.debug(`Parameters:
     - version: ${version}
     - sha: ${sha}
     - whimsical: ${whimsical}
     - projectName: ${projectName}
+    - language: ${language}
     `)
 
     const messages = await getMessages(sha)
@@ -27,7 +29,8 @@ async function run(): Promise<void> {
       version,
       projectName,
       messages,
-      whimsical
+      whimsical,
+      language
     )
 
     core.setOutput('release_body', releaseBody)

--- a/src/stringsHelper.ts
+++ b/src/stringsHelper.ts
@@ -1,0 +1,12 @@
+export const isNullOrWhitespace = (
+  value: string | null | undefined
+): boolean => {
+  if (value === null) {
+    return true
+  }
+
+  if (!value) {
+    return true
+  }
+  return value.trim().length <= 0
+}

--- a/src/supportedLanguages.ts
+++ b/src/supportedLanguages.ts
@@ -1,0 +1,25 @@
+export const supportedLanguages = [
+  'english',
+  'spanish',
+  'french',
+  'german',
+  'italian',
+  'portuguese',
+  'russian',
+  'japanese',
+  'chinese'
+]
+
+export const throwIfLanguageIsNotSupported = (language: string): void => {
+  const isLanguageSupported = supportedLanguages.includes(
+    language.trim().toLowerCase()
+  )
+
+  if (!isLanguageSupported) {
+    throw new Error(
+      `Language ${language} is not supported.\nSupported languages are: ${supportedLanguages.join(
+        ', '
+      )}`
+    )
+  }
+}


### PR DESCRIPTION
Added:
- `language` parameter
- `isNullOrWhitespace` method to check if `language` parameter is null or white space, to decide whether ChatGPT should output a message in the specified language or if everything should be the same as before. 